### PR TITLE
Fix subshell test using non-POSIX features.

### DIFF
--- a/tests/test-command.vala
+++ b/tests/test-command.vala
@@ -339,7 +339,7 @@ namespace Tests
 
         public void test_execute__use_subshell ()
         {
-            var command = new Ft.Command ("cat <<< \"hello\"");
+            var command = new Ft.Command ("printf '%s\n' hello");
             command.use_subshell = true;
 
             var context = new Ft.Context ();


### PR DESCRIPTION
## Pull request checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

The test test_execute__use_subshell() used a non-POSIX feature  specific here-string syntax (<<<) while invoking sh -c. On systems where /bin/sh is a shell not supporting this extenseion (e.g when sh is not Bash), the test fails with a shell syntax error:

```
sh -c 'cat <<< "hello"'
sh: 1: Syntax error: redirection unexpected

```

This MR replaces the command with a POSIX-compliant printf invocation that produces the same output and keeps the test shell-independent.

(This issue has been found when updating the Debian package to 1.1.2)