### PR TITLE
feat: screen overlay dismiss challenge

### DIFF
--- a/data/io.github.focustimerhq.FocusTimer.gschema.xml
+++ b/data/io.github.focustimerhq.FocusTimer.gschema.xml
@@ -66,6 +66,11 @@
       <summary>Time to reopen screen overlay</summary>
       <description></description>
     </key>
+    <key name="screen-overlay-dismiss-challenge" type="b">
+      <default>true</default>
+      <summary>Require a typing challenge to dismiss the screen overlay</summary>
+      <description>When enabled, dismissing the break overlay requires keeping a one minute typing challenge going instead of a single key press.</description>
+    </key>
 
     <!-- Appearance -->
     <key name="dark-theme" type="b">

--- a/src/ui/overlays/lightbox.vala
+++ b/src/ui/overlays/lightbox.vala
@@ -669,11 +669,16 @@ namespace Ft
             switch (keyval)
             {
                 case Gdk.Key.Escape:
-                    this.close ();
-                    return true;
+                    return this.handle_escape ();
             }
 
             return false;
+        }
+
+        protected virtual bool handle_escape ()
+        {
+            this.close ();
+            return true;
         }
 
         private bool resolve_all_monitors_mode (int width,

--- a/src/ui/overlays/screen-overlay.ui
+++ b/src/ui/overlays/screen-overlay.ui
@@ -6,68 +6,127 @@
     <property name="startup-id">focus-timer-screen-overlay</property>
     <property name="can-focus">true</property>
     <property name="contents">
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <property name="vexpand">true</property>
-        <property name="can-focus">false</property>
+      <object class="GtkStack" id="stack">
+        <property name="transition-type">crossfade</property>
         <child>
-          <object class="GtkBox">
-            <property name="halign">end</property>
-            <property name="spacing">10</property>
-            <child>
-              <object class="GtkButton" id="lock_screen_button">
+          <object class="GtkStackPage">
+            <property name="name">break</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
+                <property name="vexpand">true</property>
+                <property name="can-focus">false</property>
                 <child>
-                  <object class="GtkImage">
-                    <property name="icon-name">lock-screen-symbolic</property>
-                    <property name="pixel-size">24</property>
+                  <object class="GtkBox">
+                    <property name="halign">end</property>
+                    <property name="spacing">10</property>
+                    <child>
+                      <object class="GtkButton" id="lock_screen_button">
+                        <child>
+                          <object class="GtkImage">
+                            <property name="icon-name">lock-screen-symbolic</property>
+                            <property name="pixel-size">24</property>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="flat"/>
+                          <class name="circular"/>
+                        </style>
+                        <signal name="clicked" handler="on_lock_screen_button_clicked" swapped="no"/>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="close_button">
+                        <child>
+                          <object class="GtkImage">
+                            <property name="icon-name">screen-overlay-close-symbolic</property>
+                            <property name="pixel-size">24</property>
+                          </object>
+                        </child>
+                        <style>
+                          <class name="flat"/>
+                          <class name="circular"/>
+                        </style>
+                        <signal name="clicked" handler="on_close_button_clicked" swapped="no"/>
+                      </object>
+                    </child>
                   </object>
                 </child>
-                <style>
-                  <class name="flat"/>
-                  <class name="circular"/>
-                </style>
-                <signal name="clicked" handler="on_lock_screen_button_clicked" swapped="no"/>
-              </object>
-            </child>
-            <child>
-              <object class="GtkButton" id="close_button">
                 <child>
-                  <object class="GtkImage">
-                    <property name="icon-name">screen-overlay-close-symbolic</property>
-                    <property name="pixel-size">24</property>
+                  <object class="GtkBox">
+                    <property name="orientation">vertical</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="vexpand">true</property>
+                    <property name="spacing">6</property>
+                    <property name="margin-bottom">50</property>
+                    <child>
+                      <object class="FtTimerLabel">
+                        <property name="halign">center</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="label" translatable="yes">It's time to take a break</property>
+                        <property name="halign">center</property>
+                        <style>
+                          <class name="message"/>
+                        </style>
+                      </object>
+                    </child>
                   </object>
                 </child>
-                <style>
-                  <class name="flat"/>
-                  <class name="circular"/>
-                </style>
-                <signal name="clicked" handler="on_close_button_clicked" swapped="no"/>
               </object>
-            </child>
+            </property>
           </object>
         </child>
         <child>
-          <object class="GtkBox">
-            <property name="orientation">vertical</property>
-            <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="vexpand">true</property>
-            <property name="spacing">6</property>
-            <property name="margin-bottom">50</property>
-            <child>
-              <object class="FtTimerLabel">
+          <object class="GtkStackPage">
+            <property name="name">challenge</property>
+            <property name="child">
+              <object class="GtkBox">
+                <property name="orientation">vertical</property>
                 <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="vexpand">true</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="label" translatable="yes">Keep pressing this key to leave the break</property>
+                    <property name="halign">center</property>
+                    <style>
+                      <class name="message"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="challenge_key_label">
+                    <property name="halign">center</property>
+                    <style>
+                      <class name="challenge-key"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="challenge_time_label">
+                    <property name="halign">center</property>
+                    <style>
+                      <class name="message"/>
+                    </style>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="challenge_hint_label">
+                    <property name="label" translatable="yes">A wrong key or pausing resets the timer.</property>
+                    <property name="halign">center</property>
+                    <property name="margin-top">12</property>
+                    <style>
+                      <class name="challenge-hint"/>
+                    </style>
+                  </object>
+                </child>
               </object>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="label" translatable="yes">It's time to take a break</property>
-                <property name="halign">center</property>
-                <style>
-                  <class name="message"/>
-                </style>
-              </object>
-            </child>
+            </property>
           </object>
         </child>
       </object>

--- a/src/ui/overlays/screen-overlay.vala
+++ b/src/ui/overlays/screen-overlay.vala
@@ -9,10 +9,25 @@ namespace Ft
     [GtkTemplate (ui = "/io/github/focustimerhq/FocusTimer/ui/overlays/screen-overlay.ui")]
     public class ScreenOverlay : Ft.Lightbox
     {
+        private const uint CHALLENGE_DURATION = 60U;
+        private const uint IDLE_RESET_SECONDS = 3U;
+
         [GtkChild]
         private unowned Gtk.Button lock_screen_button;
+        [GtkChild]
+        private unowned Gtk.Stack stack;
+        [GtkChild]
+        private unowned Gtk.Label challenge_key_label;
+        [GtkChild]
+        private unowned Gtk.Label challenge_time_label;
 
-        private Ft.LockScreen? lock_screen;
+        private Ft.LockScreen?          lock_screen;
+        private Gtk.EventControllerKey? challenge_key_controller = null;
+        private bool                    challenge_active = false;
+        private uint                    challenge_remaining = 0;
+        private uint                    challenge_idle = 0;
+        private uint                    challenge_keyval = 0;
+        private uint                    challenge_source_id = 0;
 
         construct
         {
@@ -22,6 +37,17 @@ namespace Ft
                                             this.lock_screen_button,
                                             "visible",
                                             GLib.BindingFlags.SYNC_CREATE);
+
+            this.challenge_key_controller = new Gtk.EventControllerKey ();
+            this.challenge_key_controller.set_propagation_phase (Gtk.PropagationPhase.CAPTURE);
+            this.challenge_key_controller.key_pressed.connect (this.on_challenge_key_pressed);
+            ((Gtk.Widget) this).add_controller (this.challenge_key_controller);
+        }
+
+        protected override bool handle_escape ()
+        {
+            this.request_dismiss ();
+            return true;
         }
 
         [GtkCallback]
@@ -33,19 +59,147 @@ namespace Ft
         [GtkCallback]
         private void on_close_button_clicked (Gtk.Button button)
         {
+            this.request_dismiss ();
+        }
+
+        private void request_dismiss ()
+        {
+            if (this.challenge_active) {
+                return;
+            }
+
+            if (!Ft.get_settings ().get_boolean ("screen-overlay-dismiss-challenge")) {
+                this.close ();
+                return;
+            }
+
+            this.start_challenge ();
+        }
+
+        private void start_challenge ()
+        {
+            this.challenge_active = true;
+            this.challenge_remaining = CHALLENGE_DURATION;
+            this.challenge_idle = 0;
+
+            this.show_contents = true;
+            this.stack.visible_child_name = "challenge";
+
+            this.pick_challenge_key ();
+            this.update_challenge_labels ();
+
+            this.challenge_source_id = GLib.Timeout.add_seconds (1, this.on_challenge_tick);
+            GLib.Source.set_name_by_id (this.challenge_source_id, "Ft.ScreenOverlay.challenge");
+        }
+
+        private void finish_challenge ()
+        {
+            this.stop_challenge ();
             this.close ();
         }
 
-        // public override void map ()
-        // {
-        //     base.map ();
-        //
-        //    // TODO: Reset user idle-time to delay the screen-saver.
-        //    // Ft.wake_up_screen ();
-        // }
+        private void stop_challenge ()
+        {
+            this.challenge_active = false;
+
+            if (this.challenge_source_id != 0) {
+                GLib.Source.remove (this.challenge_source_id);
+                this.challenge_source_id = 0;
+            }
+        }
+
+        private bool on_challenge_tick ()
+        {
+            this.challenge_idle++;
+
+            if (this.challenge_idle >= IDLE_RESET_SECONDS) {
+                this.challenge_remaining = CHALLENGE_DURATION;
+                this.update_challenge_labels ();
+                return GLib.Source.CONTINUE;
+            }
+
+            this.challenge_remaining--;
+
+            if (this.challenge_remaining == 0) {
+                this.challenge_source_id = 0;
+                this.finish_challenge ();
+                return GLib.Source.REMOVE;
+            }
+
+            this.update_challenge_labels ();
+            return GLib.Source.CONTINUE;
+        }
+
+        private bool on_challenge_key_pressed (Gtk.EventControllerKey event_controller,
+                                               uint                   keyval,
+                                               uint                   keycode,
+                                               Gdk.ModifierType       state)
+        {
+            if (!this.challenge_active) {
+                return false;
+            }
+
+            if (is_modifier_key (keyval)) {
+                return true;
+            }
+
+            this.challenge_idle = 0;
+            this.challenge_key_label.remove_css_class ("wrong");
+
+            if (Gdk.keyval_to_lower (keyval) != this.challenge_keyval) {
+                this.challenge_remaining = CHALLENGE_DURATION;
+                this.challenge_key_label.add_css_class ("wrong");
+            }
+
+            this.update_challenge_labels ();
+            return true;
+        }
+
+        private void pick_challenge_key ()
+        {
+            var offset = GLib.Random.int_range (0, 26);
+
+            this.challenge_keyval = (uint) Gdk.Key.a + (uint) offset;
+            this.challenge_key_label.label = ((char) ('A' + offset)).to_string ();
+        }
+
+        private void update_challenge_labels ()
+        {
+            this.challenge_time_label.label = "%02u:%02u".printf (
+                                this.challenge_remaining / 60U,
+                                this.challenge_remaining % 60U);
+        }
+
+        private static bool is_modifier_key (uint keyval)
+        {
+            switch (keyval)
+            {
+                case Gdk.Key.Shift_L:
+                case Gdk.Key.Shift_R:
+                case Gdk.Key.Control_L:
+                case Gdk.Key.Control_R:
+                case Gdk.Key.Alt_L:
+                case Gdk.Key.Alt_R:
+                case Gdk.Key.Meta_L:
+                case Gdk.Key.Meta_R:
+                case Gdk.Key.Super_L:
+                case Gdk.Key.Super_R:
+                case Gdk.Key.Hyper_L:
+                case Gdk.Key.Hyper_R:
+                case Gdk.Key.Caps_Lock:
+                case Gdk.Key.Shift_Lock:
+                case Gdk.Key.Num_Lock:
+                case Gdk.Key.ISO_Level3_Shift:
+                    return true;
+                default:
+                    return false;
+            }
+        }
 
         public override void dispose ()
         {
+            this.stop_challenge ();
+
             this.lock_screen = null;
 
             base.dispose ();

--- a/src/ui/preferences/notifications/preferences-panel-notifications.ui
+++ b/src/ui/preferences/notifications/preferences-panel-notifications.ui
@@ -44,6 +44,12 @@
                     <property name="subtitle" translatable="yes">Period of inactivity to reopen the overlay after it gets dismissed.</property>
                   </object>
                 </child>
+                <child>
+                  <object class="AdwSwitchRow" id="screen_overlay_dismiss_challenge_switchrow">
+                    <property name="title" translatable="yes">Dismiss Challenge</property>
+                    <property name="subtitle" translatable="yes">Require a one minute typing challenge to leave the break instead of a single key press.</property>
+                  </object>
+                </child>
               </object>
             </child>
           </object>

--- a/src/ui/preferences/notifications/preferences-panel-notifications.vala
+++ b/src/ui/preferences/notifications/preferences-panel-notifications.vala
@@ -21,6 +21,8 @@ namespace Ft
         private unowned Adw.ComboRow screen_overlay_lock_delay_comborow;
         [GtkChild]
         private unowned Adw.ComboRow screen_overlay_reopen_delay_comborow;
+        [GtkChild]
+        private unowned Adw.SwitchRow screen_overlay_dismiss_challenge_switchrow;
 
         private GLib.Settings?  settings;
         private Ft.IdleMonitor? idle_monitor = null;
@@ -82,6 +84,15 @@ namespace Ft
             this.screen_overlay_switchrow.bind_property (
                                 "active",
                                 this.screen_overlay_reopen_delay_comborow,
+                                "sensitive",
+                                GLib.BindingFlags.SYNC_CREATE);
+            this.settings.bind ("screen-overlay-dismiss-challenge",
+                                this.screen_overlay_dismiss_challenge_switchrow,
+                                "active",
+                                GLib.SettingsBindFlags.DEFAULT);
+            this.screen_overlay_switchrow.bind_property (
+                                "active",
+                                this.screen_overlay_dismiss_challenge_switchrow,
                                 "sensitive",
                                 GLib.BindingFlags.SYNC_CREATE);
         }

--- a/src/ui/style.css
+++ b/src/ui/style.css
@@ -508,6 +508,21 @@ lightbox .message {
     font-size: 14pt;
 }
 
+lightbox .challenge-key {
+    font-size: 110pt;
+    font-weight: 700;
+    min-width: 120px;
+}
+
+lightbox .challenge-key.wrong {
+    color: #ff6b6b;
+}
+
+lightbox .challenge-hint {
+    font-size: 11pt;
+    opacity: 0.6;
+}
+
 lightbox button {
     padding: 10px;
 }


### PR DESCRIPTION
Instead of pressing escape to immediately dismiss the pomodoro timer, this will force the user to press a random button for one minute to dismiss the reminder

## Pull request checklist

- [ ] Lint and unit tests pass locally with my changes
- [ ] Extended the README / documentation, if necessary

## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

## What is the new behavior?

(Write your answer here.)

## Other information

(Write your answer here.)
